### PR TITLE
feat: Windows portable build + separate screenshot from AI analysis (v1.1.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,86 +9,142 @@ on:
     branches: [main]
 
 jobs:
+  # ── PR 构建：验证两平台均可编译 ──────────────────────────────────────────────
   build-pr:
-    name: Build
+    name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: 'macos-latest'
           - platform: 'windows-latest'
-    if: github.event_name == 'pull_request'
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install npm dependencies
-        run: npm ci
+      - run: npm ci
 
-      - name: Build
+      - name: Build (macOS)
+        if: matrix.platform == 'macos-latest'
         run: npm run tauri build
 
-      - name: Upload artifact
+      - name: Build Windows app (no installer)
+        if: matrix.platform == 'windows-latest'
+        run: npm run tauri build -- --bundles none
+
+      - name: Package Windows portable zip
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          Copy-Item "src-tauri\target\release\daily-logger.exe" "DailyLogger.exe"
+          Compress-Archive -Path "DailyLogger.exe" -DestinationPath "DailyLogger-windows-portable.zip"
+
+      - name: Upload macOS artifact
+        if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: app-${{ matrix.platform }}
+          name: app-macos
           path: src-tauri/target/release/bundle/**/*
 
-  build:
+      - name: Upload Windows artifact
+        if: matrix.platform == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-windows-portable
+          path: DailyLogger-windows-portable.zip
+
+  # ── Tag 推送：先建 Release，再并行构建两平台 ──────────────────────────────────
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: 'macos-latest'
-            args: '--target aarch64-apple-darwin'
-          - platform: 'windows-latest'
-
-    runs-on: ${{ matrix.platform }}
-    if: startsWith(github.ref_name, 'v')
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Create draft release
+        id: create
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "DailyLogger ${{ github.ref_name }}" \
+            --notes "See the assets to download this version." \
+            --draft
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq .id)
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+
+  build-macos:
+    name: Build macOS
+    needs: create-release
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
 
-      - name: Install dependencies (Ubuntu)
-        if: matrix.platform == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - run: npm ci
 
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v__VERSION__
-          releaseName: 'DailyLogger v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
-          prerelease: false
-          args: ${{ matrix.args }}
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          args: '--target aarch64-apple-darwin'
+
+  build-windows:
+    name: Build Windows (Portable)
+    needs: create-release
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: npm ci
+
+      - name: Build Windows app (no installer)
+        run: npm run tauri build -- --bundles none
+
+      - name: Package as portable zip
+        shell: pwsh
+        run: |
+          Copy-Item "src-tauri\target\release\daily-logger.exe" "DailyLogger.exe"
+          Compress-Archive -Path "DailyLogger.exe" `
+            -DestinationPath "DailyLogger-${{ github.ref_name }}-windows-portable.zip"
+
+      - name: Upload to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" "DailyLogger-${{ github.ref_name }}-windows-portable.zip"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "daily-logger"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daily-logger"
-version = "1.0.0"
+version = "1.1.0"
 description = "AI Workflow Memory & Summary Agent"
 authors = ["DailyLogger"]
 edition = "2021"

--- a/src-tauri/src/auto_perception/mod.rs
+++ b/src-tauri/src/auto_perception/mod.rs
@@ -256,3 +256,14 @@ pub async fn trigger_capture() -> Result<(), String> {
     tracing::info!("Manual capture triggered");
     Ok(())
 }
+
+/// 只截图并保存到磁盘，不调用 AI 分析，不写数据库记录。
+/// 返回截图文件的绝对路径，供前端直接预览。
+#[command]
+pub async fn take_screenshot() -> Result<String, String> {
+    let image_base64 = capture_screen()?;
+    let path = save_screenshot(&image_base64)
+        .ok_or_else(|| "截图保存失败".to_string())?;
+    tracing::info!("Screenshot saved for preview: {}", path);
+    Ok(path)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
             daily_logger_lib::auto_perception::start_auto_capture,
             daily_logger_lib::auto_perception::stop_auto_capture,
             daily_logger_lib::auto_perception::trigger_capture,
+            daily_logger_lib::auto_perception::take_screenshot,
             daily_logger_lib::manual_entry::add_quick_note,
             daily_logger_lib::manual_entry::get_screenshot,
             daily_logger_lib::manual_entry::read_file,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DailyLogger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.dailylogger.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -43,11 +43,7 @@
     "windows": {
       "certificateThumbprint": null,
       "digestAlgorithm": "sha256",
-      "timestampUrl": "",
-      "wix": null,
-      "nsis": {
-        "installMode": "currentUser"
-      }
+      "timestampUrl": ""
     }
   },
   "plugins": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,8 +9,8 @@
       </div>
       <div class="flex items-center gap-4">
         <span class="text-sm text-gray-400">{{ currentTime }}</span>
-        <button @click="showLogViewer = true" class="p-2 hover:bg-gray-700 rounded-lg transition-colors" title="查看日志">
-          🗒️
+        <button @click="showLogViewer = true" class="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors">
+          🗒️ 日志
         </button>
         <button @click="showSettings = true" class="p-2 hover:bg-gray-700 rounded-lg transition-colors">
           ⚙️
@@ -34,12 +34,20 @@
               </div>
               <div class="flex items-center gap-2">
                 <button
+                  @click="takeScreenshot"
+                  :disabled="isCapturing"
+                  class="px-3 py-1.5 text-xs bg-gray-600 hover:bg-gray-500 disabled:opacity-50 rounded-lg transition-colors"
+                  title="截图查看，不做 AI 分析"
+                >
+                  {{ isCapturing ? '截图中…' : '📸 截图' }}
+                </button>
+                <button
                   @click="triggerCapture"
                   :disabled="isCapturing"
                   class="px-3 py-1.5 text-xs bg-gray-600 hover:bg-gray-500 disabled:opacity-50 rounded-lg transition-colors"
-                  title="立即截图一次"
+                  title="截图并进行 AI 分析，保存到记录"
                 >
-                  {{ isCapturing ? '截图中…' : '📸 立即截图' }}
+                  🤖 分析
                 </button>
                 <button
                   @click="toggleAutoCapture"
@@ -209,6 +217,24 @@ const toggleAutoCapture = async () => {
     autoCaptureEnabled.value = !autoCaptureEnabled.value
   } catch (err) {
     console.error('Failed to toggle auto capture:', err)
+  }
+}
+
+const takeScreenshot = async () => {
+  if (isCapturing.value) return
+  isCapturing.value = true
+  try {
+    const path = await invoke('take_screenshot')
+    selectedScreenshot.value = {
+      screenshot_path: path,
+      timestamp: new Date().toISOString(),
+      content: null,
+    }
+    showScreenshot.value = true
+  } catch (err) {
+    console.error('Failed to take screenshot:', err)
+  } finally {
+    isCapturing.value = false
   }
 }
 

--- a/src/components/ScreenshotModal.vue
+++ b/src/components/ScreenshotModal.vue
@@ -20,9 +20,12 @@
         <div class="mt-4 p-4 bg-darker rounded-lg">
           <div class="flex items-center justify-between mb-2">
             <span class="text-xs text-gray-500">{{ formatTime(record.timestamp) }}</span>
-            <span class="text-xs text-blue-400">🖥️ 自动截图</span>
+            <span class="text-xs" :class="record.content ? 'text-blue-400' : 'text-gray-500'">
+              {{ record.content ? '🖥️ 已分析' : '📸 仅截图预览' }}
+            </span>
           </div>
-          <p class="text-sm text-gray-300 whitespace-pre-wrap">{{ parseContent(record.content) }}</p>
+          <p v-if="record.content" class="text-sm text-gray-300 whitespace-pre-wrap">{{ parseContent(record.content) }}</p>
+          <p v-else class="text-sm text-gray-500 italic">未进行 AI 分析</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Windows 构建**：移除 NSIS 安装包，改为输出可直接运行的 .zip 便携包；重构 Release workflow 为 create-release + build-macos + build-windows 并行执行
- **截图与分析分离**：新增 take_screenshot backend command（只截图保存磁盘，不调用 AI、不写 DB）；UI 拆分为截图（仅预览）和分析（截图+AI+保存记录）两个按钮
- **日志入口可见性**：将 header 中仅有图标的隐藏按钮改为文字按钮

## Test plan

- [ ] Windows CI 构建产出 DailyLogger-v1.1.0-windows-portable.zip，解压后可直接运行
- [ ] 点击截图按钮：弹出预览，无 AI 分析，不增加今日记录
- [ ] 点击分析按钮：截图 + AI 分析 + 今日记录新增一条
- [ ] Header 右侧能看到日志按钮，点击打开日志查看界面